### PR TITLE
[W7][T09-1] Ngo Wei Lin

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -147,4 +147,19 @@ Format: `exit`
 
 Address book data are saved in the hard disk automatically after any command that changes the data.
 
+[NOTE]
+====
+Address book data is not saved in the hard disk if there are no changes to the data, which happens if: +
+
+. the command entered is invalid +
+. `clear` command is executed on an empty Address book +
+. any of the following commands is executed: +
+  .. `exit` +
+  .. `find` +
+  .. `help` +
+  .. `list` +
+  .. `view` +
+  .. `viewall`
+====
+
 There is no need to save manually. Address book data are saved in a file called `addressbook.txt` in the project root folder.

--- a/src/seedu/addressbook/commands/AddCommand.java
+++ b/src/seedu/addressbook/commands/AddCommand.java
@@ -58,10 +58,12 @@ public class AddCommand extends Command {
 
     @Override
     public CommandResult execute() {
+        isMutating = true;
         try {
             addressBook.addPerson(toAdd);
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
         } catch (UniquePersonList.DuplicatePersonException dpe) {
+            isMutating = false;
             return new CommandResult(MESSAGE_DUPLICATE_PERSON);
         }
     }

--- a/src/seedu/addressbook/commands/ClearCommand.java
+++ b/src/seedu/addressbook/commands/ClearCommand.java
@@ -13,7 +13,13 @@ public class ClearCommand extends Command {
 
     @Override
     public CommandResult execute() {
-        addressBook.clear();
+        if (addressBook.getAllPersons().immutableListView().isEmpty()) {
+            isMutating = false;
+        }
+        else {
+            isMutating = true;
+            addressBook.clear();
+        }
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/seedu/addressbook/commands/Command.java
+++ b/src/seedu/addressbook/commands/Command.java
@@ -13,6 +13,7 @@ import static seedu.addressbook.ui.Gui.DISPLAYED_INDEX_OFFSET;
  */
 public abstract class Command {
     protected AddressBook addressBook;
+    protected boolean isMutating = true;
     protected List<? extends ReadOnlyPerson> relevantPersons;
     private int targetIndex = -1;
 
@@ -69,5 +70,14 @@ public abstract class Command {
 
     public void setTargetIndex(int targetIndex) {
         this.targetIndex = targetIndex;
+    }
+
+    /**
+     * Returns whether the command mutated the Address Book data.
+     *
+     * @return {@code true} if Address Book data mutated, {@code false} if otherwise
+     */
+    public boolean isMutating() {
+        return isMutating;
     }
 }

--- a/src/seedu/addressbook/commands/DeleteCommand.java
+++ b/src/seedu/addressbook/commands/DeleteCommand.java
@@ -27,14 +27,16 @@ public class DeleteCommand extends Command {
 
     @Override
     public CommandResult execute() {
+        isMutating = true;
         try {
             final ReadOnlyPerson target = getTargetPerson();
             addressBook.removePerson(target);
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, target));
-
         } catch (IndexOutOfBoundsException ie) {
+            isMutating = false;
             return new CommandResult(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         } catch (PersonNotFoundException pnfe) {
+            isMutating = false;
             return new CommandResult(Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK);
         }
     }

--- a/src/seedu/addressbook/commands/ExitCommand.java
+++ b/src/seedu/addressbook/commands/ExitCommand.java
@@ -13,6 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute() {
+        isMutating = false;
         return new CommandResult(MESSAGE_EXIT_ACKNOWEDGEMENT);
     }
 

--- a/src/seedu/addressbook/commands/FindCommand.java
+++ b/src/seedu/addressbook/commands/FindCommand.java
@@ -32,6 +32,7 @@ public class FindCommand extends Command {
 
     @Override
     public CommandResult execute() {
+        isMutating = false;
         final List<ReadOnlyPerson> personsFound = getPersonsWithNameContainingAnyKeyword(keywords);
         return new CommandResult(getMessageForPersonListShownSummary(personsFound), personsFound);
     }

--- a/src/seedu/addressbook/commands/HelpCommand.java
+++ b/src/seedu/addressbook/commands/HelpCommand.java
@@ -23,6 +23,7 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute() {
+        isMutating = false;
         return new CommandResult(MESSAGE_ALL_USAGES);
     }
 }

--- a/src/seedu/addressbook/commands/IncorrectCommand.java
+++ b/src/seedu/addressbook/commands/IncorrectCommand.java
@@ -14,6 +14,7 @@ public class IncorrectCommand extends Command{
 
     @Override
     public CommandResult execute() {
+        isMutating = false;
         return new CommandResult(feedbackToUser);
     }
 

--- a/src/seedu/addressbook/commands/ListCommand.java
+++ b/src/seedu/addressbook/commands/ListCommand.java
@@ -19,6 +19,7 @@ public class ListCommand extends Command {
 
     @Override
     public CommandResult execute() {
+        isMutating = false;
         List<ReadOnlyPerson> allPersons = addressBook.getAllPersons().immutableListView();
         return new CommandResult(getMessageForPersonListShownSummary(allPersons), allPersons);
     }

--- a/src/seedu/addressbook/commands/ViewAllCommand.java
+++ b/src/seedu/addressbook/commands/ViewAllCommand.java
@@ -27,6 +27,7 @@ public class ViewAllCommand extends Command {
 
     @Override
     public CommandResult execute() {
+        isMutating = false;
         try {
             final ReadOnlyPerson target = getTargetPerson();
             if (!addressBook.containsPerson(target)) {

--- a/src/seedu/addressbook/commands/ViewCommand.java
+++ b/src/seedu/addressbook/commands/ViewCommand.java
@@ -27,6 +27,7 @@ public class ViewCommand extends Command {
 
     @Override
     public CommandResult execute() {
+        isMutating = false;
         try {
             final ReadOnlyPerson target = getTargetPerson();
             if (!addressBook.containsPerson(target)) {

--- a/src/seedu/addressbook/logic/Logic.java
+++ b/src/seedu/addressbook/logic/Logic.java
@@ -85,7 +85,9 @@ public class Logic {
     private CommandResult execute(Command command) throws Exception {
         command.setData(addressBook, lastShownList);
         CommandResult result = command.execute();
-        storage.save(addressBook);
+        if (command.isMutating()) {
+            storage.save(addressBook);
+        }
         return result;
     }
 

--- a/test/java/seedu/addressbook/logic/LogicTest.java
+++ b/test/java/seedu/addressbook/logic/LogicTest.java
@@ -89,6 +89,7 @@ public class LogicTest {
         //Confirm the state of data is as expected
         assertEquals(expectedAddressBook, addressBook);
         assertEquals(lastShownList, logic.getLastShownList());
+        saveFile.save(addressBook);
         assertEquals(addressBook, saveFile.load());
     }
 


### PR DESCRIPTION
```
User Guide states that Address book data are saved in the hard disk 
automatically after any command that changes the data.

This is incorrect, as the application saves Address book data to storage
file after executing any command, which violates the behavior described.

In addition, this behavior is briefly documented in the User Guide only.
Users are not informed exactly which commands trigger saving of data to
storage file, and when commands don't do so.

Let's fix this by actually saving Address book data to storage file only
when the data of the Address Book has mutated, and update the 
documentation to include a detailed listing of behavior that do not 
cause the Address book data to be changed and hence do not trigger 
saving of data to the storage file.
```